### PR TITLE
Make env variable default parameter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+export CONSUMER_KEY=
+export SECRET_KEY=

--- a/.env_example
+++ b/.env_example
@@ -1,2 +1,0 @@
-export CONSUMER_KEY=ghgfdsghj
-export SECRET_KEY=dgsgfhfdd

--- a/mvola/core.py
+++ b/mvola/core.py
@@ -9,8 +9,8 @@ from .tools import ResultAction
 class Mvola:
     def __init__(
         self,
-        consumer_key: str,
-        consumer_secret: str,
+        consumer_key: str = env.get("CONSUMER_KEY"),
+        consumer_secret: str = env.get("SECRET_KEY"),
         status: str = "SANDBOX",
         token: str = None,
     ):
@@ -23,6 +23,12 @@ class Mvola:
             consumer_secret (str ): Consumer secret of the application's API
             status (str, optional): The status of your API (SANDBOX : Developer Mode / PRODUCTION : Api deployé). Defaults to "SANDBOX".
         """
+
+        if not consumer_key:
+            raise Exception("Missing CONSUMER_KEY in env")
+        if not consumer_secret:
+            raise Exception("Missing SECRET_KEY in env")
+            
         self.key = consumer_key
         self.secret = consumer_secret
         self.type = status

--- a/mvola/core.py
+++ b/mvola/core.py
@@ -3,6 +3,7 @@
 import json
 import requests
 import base64
+from os import environ as env
 from .tools import ResultAction
 
 
@@ -28,7 +29,7 @@ class Mvola:
             raise Exception("Missing CONSUMER_KEY in env")
         if not consumer_secret:
             raise Exception("Missing SECRET_KEY in env")
-            
+
         self.key = consumer_key
         self.secret = consumer_secret
         self.type = status


### PR DESCRIPTION
```python
from mvola import Mvola

api = Mvola()
```

if no parameter in the Mvola instance, get the env variable, 
raise an error if the env variable is not define 

